### PR TITLE
feat(test-harness): add cleanup endpoint to force fresh document re-u…

### DIFF
--- a/srv/agent/.gitignore
+++ b/srv/agent/.gitignore
@@ -1,0 +1,151 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+.pdm.toml
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.env.*
+!.env.example
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Project specific
+*.db
+*.sqlite

--- a/srv/agent/app/config/settings.py
+++ b/srv/agent/app/config/settings.py
@@ -1,7 +1,8 @@
 from functools import lru_cache
 from typing import List, Optional
 
-from pydantic import AnyHttpUrl, BaseSettings, Field
+from pydantic import AnyHttpUrl, Field
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/srv/agent/app/models/domain.py
+++ b/srv/agent/app/models/domain.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
@@ -11,6 +11,10 @@ from app.models.base import Base
 
 def _uuid() -> uuid.UUID:
     return uuid.uuid4()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 class AgentDefinition(Base):
@@ -27,9 +31,9 @@ class AgentDefinition(Base):
     scopes: Mapped[list] = mapped_column(JSONB, default=list)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     version: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -44,9 +48,9 @@ class ToolDefinition(Base):
     scopes: Mapped[list] = mapped_column(JSONB, default=list)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     version: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -59,9 +63,9 @@ class WorkflowDefinition(Base):
     steps: Mapped[list] = mapped_column(JSONB, default=list)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     version: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -74,9 +78,9 @@ class EvalDefinition(Base):
     config: Mapped[dict] = mapped_column(JSONB, default=dict)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     version: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -88,9 +92,9 @@ class RagDatabase(Base):
     description: Mapped[Optional[str]] = mapped_column(Text)
     config: Mapped[dict] = mapped_column(JSONB, default=dict)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -103,9 +107,9 @@ class RagDocument(Base):
     )
     path: Mapped[str] = mapped_column(String(255))
     metadata: Mapped[dict] = mapped_column(JSONB, default=dict)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
     database: Mapped[RagDatabase] = relationship("RagDatabase", lazy="selectin")
@@ -122,9 +126,9 @@ class RunRecord(Base):
     output: Mapped[Optional[dict]] = mapped_column(JSONB)
     events: Mapped[list] = mapped_column(JSONB, default=list)
     created_by: Mapped[Optional[str]] = mapped_column(String(255))
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_now, onupdate=_now
     )
 
 
@@ -136,4 +140,4 @@ class TokenGrant(Base):
     scopes: Mapped[list] = mapped_column(JSONB, default=list)
     token: Mapped[str] = mapped_column(Text)
     expires_at: Mapped[datetime] = mapped_column(DateTime)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)

--- a/srv/ingest/src/api/routes/test_docs.py
+++ b/srv/ingest/src/api/routes/test_docs.py
@@ -245,6 +245,71 @@ async def get_test_docs_status(request: Request):
     }
 
 
+@router.post("/test-docs/cleanup")
+async def cleanup_test_docs(request: Request):
+    """
+    Delete all test documents and clear state.
+    
+    This forces a fresh re-upload on next seed, useful for testing
+    ingestion pipeline changes.
+    """
+    if not request.headers.get("Authorization"):
+        return JSONResponse(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content={"error": "Authorization header required"},
+        )
+
+    state = _load_state()
+    deleted = []
+    errors = []
+
+    headers = {
+        "Authorization": request.headers.get("Authorization", ""),
+        "X-User-Id": getattr(request.state, "user_id", ""),
+    }
+
+    # Delete all files from state
+    for doc_id, file_id in state.items():
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.delete(
+                    f"http://{API_HOST}:{API_PORT}/files/{file_id}",
+                    headers=headers
+                )
+                if response.status_code >= 400:
+                    errors.append({
+                        "docId": doc_id,
+                        "fileId": file_id,
+                        "error": response.text
+                    })
+                else:
+                    deleted.append({
+                        "docId": doc_id,
+                        "fileId": file_id
+                    })
+        except Exception as e:
+            errors.append({
+                "docId": doc_id,
+                "fileId": file_id,
+                "error": str(e)
+            })
+
+    # Clear state file
+    _save_state({})
+    
+    logger.info(
+        "Test docs cleanup completed",
+        deleted_count=len(deleted),
+        error_count=len(errors)
+    )
+
+    return {
+        "deleted": deleted,
+        "errors": errors,
+        "message": f"Deleted {len(deleted)} documents, {len(errors)} errors"
+    }
+
+
 @router.post("/test-docs/seed")
 async def seed_test_docs(request: Request):
     """
@@ -253,6 +318,8 @@ async def seed_test_docs(request: Request):
     These documents work with basic pdfplumber extraction and don't require
     GPU services (Marker/ColPali). Use /test-docs/seed-complex for documents
     that require advanced extraction.
+    
+    Use /test-docs/cleanup first to force fresh re-upload.
     """
     if not request.headers.get("Authorization"):
         return JSONResponse(


### PR DESCRIPTION
…pload

**Problem**: Cached files prevent testing ingestion pipeline changes. Upload API returns existing file without queueing new job, so worker never processes and no chunks/vectors are generated.

**Solution**: Add cleanup endpoint to delete all test documents and clear state, forcing fresh re-upload on next seed.

**Changes**:
- srv/ingest/src/api/routes/test_docs.py:
  - Added POST /test-docs/cleanup endpoint
  - Deletes all files from state via DELETE /files/{id}
  - Clears state file to force fresh upload
  - Returns deleted count and any errors
  - Updated /test-docs/seed docstring to mention cleanup

- ai-portal/src/app/api/admin/tests/docs/cleanup/route.ts (NEW):
  - Proxy endpoint for cleanup with auth
  - Calls ingest-api /test-docs/cleanup
  - Returns success/error with deleted count

- ai-portal/src/components/admin/TestPermissionsHarness.tsx:
  - Added cleanupDocs() function
  - Added 'Cleanup & Reset' button (danger variant)
  - Logs cleanup progress
  - Auto-refreshes docs after cleanup

**Usage**:
1. Click 'Cleanup & Reset' to delete all test docs
2. Click 'Seed docs' to upload fresh copies
3. Worker will process from scratch
4. Chunks/vectors/markdown will be generated

**Result**:
- Can test ingestion changes without manual DB cleanup
- Forces complete re-processing of documents
- Useful for debugging worker issues
- Clean slate for each test run