### PR TITLE
Prepare repo for v0.1.0 OSS launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report a reproducible problem with Busibox
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in the sections below so we can
+        reproduce the issue. **Do not file security vulnerabilities here** —
+        see [SECURITY.md](https://github.com/jazzmind/busibox/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what's wrong.
+      placeholder: "Agent API returns 500 when uploading a PDF larger than 50 MB."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, ordered steps. Include `make` / `curl` commands where useful.
+      placeholder: |
+        1. `make docker-up`
+        2. POST a 60 MB PDF to /v1/files
+        3. Observe 500 in nginx logs
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include relevant log lines, status codes, stack traces.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment mode
+      options:
+        - Local Docker (docker-compose)
+        - Proxmox LXC
+        - Kubernetes
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Busibox version / commit SHA
+      placeholder: "v0.1.0 or 7a609357"
+    validations:
+      required: true
+
+  - type: input
+    id: host_os
+    attributes:
+      label: Host OS / arch
+      placeholder: "macOS 14.5 arm64 / Ubuntu 22.04 amd64"
+
+  - type: textarea
+    id: env
+    attributes:
+      label: LLM provider configuration
+      description: Which providers were configured? (OpenAI, Anthropic, Bedrock, Ollama, vLLM, MLX). Do **not** paste API keys.
+      placeholder: "OPENAI_API_KEY set; no local models."
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Logs, screenshots, related issues, things you've already tried.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability (private)
+    url: https://github.com/jazzmind/busibox/security/advisories/new
+    about: Please report security issues privately. See SECURITY.md for details.
+  - name: Question or discussion
+    url: https://github.com/jazzmind/busibox/discussions
+    about: Open-ended questions, design discussions, and "is anyone else hitting this?" go in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+title: "[feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Busibox is early-stage (v0.1.x), so we're
+        especially interested in proposals that align with the existing
+        architecture (Zero-Trust auth, RLS, Docker / Proxmox / K8s parity,
+        single-tenant multi-user model).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that Busibox makes hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the change. APIs, UI, config, schema — whichever applies.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you ruled out, and why.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Approximate scope
+      options:
+        - Small — one file or a doc change
+        - Medium — touches one service or a couple of integrations
+        - Large — new service, new schema, or cross-cutting refactor
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Links to prior art, related issues, willingness to send a PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for the PR! A few notes before you submit:
+
+- Keep the change narrow. Unrelated cleanups belong in separate PRs.
+- For substantial changes (new service, schema migration, new auth path),
+  please open an issue first.
+- Security issues: do NOT submit a PR — see SECURITY.md.
+-->
+
+## Summary
+
+<!-- One or two sentences. What does this PR change, and why? -->
+
+## Related issue
+
+<!-- Closes #123 / refs #456. Delete if not applicable. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no behaviour change)
+- [ ] Documentation
+- [ ] Build / CI / tooling
+
+## Testing
+
+<!--
+What did you do to convince yourself this works?
+Examples:
+  - `cd cli && cargo test`
+  - `make test-docker SERVICE=agent ARGS=tests/integration/test_X.py`
+  - Manually uploaded a PDF, hit /v1/search, observed correct results
+-->
+
+## Checklist
+
+- [ ] Scope is narrow and focused
+- [ ] Tests added / updated where practical
+- [ ] Docs updated for user-visible changes (env vars, flags, endpoints)
+- [ ] No new service-to-service shared secrets (Zero-Trust JWT only)
+- [ ] No secrets / vault files / `.env*` committed
+- [ ] CHANGELOG.md updated under `## [Unreleased]` (for user-visible changes)
+- [ ] If a new dependency was added, its license is permissive (MIT / BSD /
+      Apache-2.0 / ISC). Otherwise, called out below.
+
+## Notes for reviewers
+
+<!-- Anything reviewers should know? Tricky bits, follow-ups, known limitations. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to Busibox will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once it reaches 1.0.0. While in 0.x, minor versions may include breaking
+changes — see release notes per version.
+
+## [Unreleased]
+
+## [0.1.0] — 2026-05-04
+
+Initial public, MIT-licensed release of Busibox. This is an **early-stage
+preview** intended for evaluation, lab use, and design-partner pilots. It
+has not yet had an independent security audit and APIs / schemas are
+expected to evolve before 1.0.
+
+### Added
+
+- **MIT license** (`LICENSE`) and accompanying `NOTICE` listing the
+  per-component license obligations for bundled and optional third-party
+  components.
+- **OSS governance files**: `SECURITY.md`, `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, GitHub issue / PR templates under `.github/`.
+- **Docker + cloud-key first-run path** as the recommended evaluation
+  flow: bring an OpenAI, Anthropic, or AWS Bedrock key, run
+  `make docker-up`, and skip GPU / local-inference setup. Documented in
+  `README.md`, `QUICKSTART.md`, and
+  `docs/administrators/01-quickstart.md`.
+- **Local model add-on pack design doc** at
+  `docs/administrators/local-models-addon.md` describing the proposed
+  Ollama / vLLM / MLX profile layout, install UX, and acceptance criteria.
+- **Release checklist** at `docs/developers/release-checklist.md`.
+
+### Existing capabilities (carried forward into 0.1.0)
+
+These were already present in the codebase prior to this tag and are
+listed here so the first public changelog gives a complete picture.
+
+- **Self-hosted document platform** with PDF / Office / image ingest,
+  chunking, embeddings, and hybrid search (vector + BM25 + graph + LLM
+  rerank).
+- **Agent API** (FastAPI) with streaming chat, RAG, tool use, attachments,
+  and configurable per-agent guardrails (request limits, token / cost
+  budgets, timeouts).
+- **LiteLLM gateway** routing across OpenAI, Anthropic, AWS Bedrock,
+  vLLM (NVIDIA), MLX (Apple Silicon), and Ollama.
+- **Zero-Trust auth**: AuthZ service issues RS256 JWTs verified via JWKS;
+  per-service audience-scoped subject token exchange. No shared service
+  secrets.
+- **Passwordless auth** (passkeys, TOTP, magic links) with optional SSO
+  via EntraID / SAML.
+- **PostgreSQL Row-Level Security** end-to-end for tenant isolation.
+- **Envelope encryption** for object storage (Master Key → KEK → DEK).
+- **Three-mode document sharing** (private / shared / team) via
+  self-service roles.
+- **Bridge channels** for Telegram, Signal, Discord, WhatsApp, email.
+- **Busibox CLI** (Rust workspace: `busibox-core`, `busibox-providers`,
+  `busibox`, `busibox-quick`) for interactive setup, deployment, and
+  fleet management across Docker, Proxmox LXC, and Kubernetes.
+- **Three MCP servers** (`mcp-core-dev`, `mcp-app-builder`, `mcp-admin`)
+  for AI-coding-agent workflows.
+- **Ansible-vault-backed secrets** with AES-256-GCM-encrypted vault keys
+  and Argon2id key derivation; SSH-piped vault password delivery.
+- **OWASP API Security Top 10 test suite** under `tests/security/`.
+
+### Known limitations
+
+- **No independent security audit yet.** The architecture is designed for
+  isolation, but the implementation has not been third-party reviewed.
+- **`data` worker pulls AGPL / source-available components** (PyMuPDF,
+  marker-pdf, surya-ocr) when the optional Marker / advanced-PDF path is
+  enabled. The project source is MIT, but operators redistributing a
+  Docker image with these components must comply with their licenses.
+  See `NOTICE`. They can be disabled via `MARKER_ENABLED=false` and
+  `COLPALI_ENABLED=false`.
+- **Bundled service images carry their own licenses.** The default
+  compose file uses Redis 7 (SSPL/RSALv2), MinIO (AGPL-3.0), and Neo4j
+  Community (GPL-3.0). These do not affect the Busibox source license,
+  but they affect redistribution of a bundled image. Tracked for a future
+  release.
+- **First-run defaults are insecure.** `env.local.example` contains
+  placeholder credentials (`devpassword`, `local-master-key-change-in-production`,
+  etc.) suitable only for local evaluation. Production deployments must
+  rotate these — the CLI does this automatically via the Ansible vault.
+- **Single-tenant by design.** Busibox isolates users within an
+  installation, not organisations. Multi-org tenancy is not on the 0.1
+  roadmap.
+- **Schema and API churn expected.** Until 1.0, expect breaking changes
+  across minor versions.
+
+### Removed
+
+- Nothing — this is the first public release.
+
+### Security
+
+- Reporting process documented in `SECURITY.md`.
+- Default `.env` values are clearly marked as insecure and intended for
+  local evaluation only.
+
+[Unreleased]: https://github.com/jazzmind/busibox/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jazzmind/busibox/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests,
+discussions, chat channels, events), and also when an individual is officially
+representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainers at **conduct@jazzmind.com** (or
+`wes@sonnenreich.com` if that bounces). All complaints will be reviewed and
+investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+1. **Correction** — Private, written warning, with clarity around the nature
+   of the violation and an explanation of why the behaviour was inappropriate.
+2. **Warning** — A warning with consequences for continued behaviour. No
+   interaction with the people involved, including unsolicited interaction with
+   those enforcing the Code of Conduct, for a specified period of time.
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public
+   communication with the community for a specified period of time.
+4. **Permanent Ban** — A permanent ban from any sort of public interaction
+   within the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant][homepage], version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to Busibox
+
+Thanks for your interest in Busibox. This document covers how to set up a
+local environment, where to put things, and what to expect when you open a
+pull request. It is deliberately short — for deeper architectural context,
+follow the links into `docs/`.
+
+## Project status and expectations
+
+Busibox is at **v0.1.x**. Interfaces, schemas, and CLI flags may change
+between minor versions. We welcome contributions but cannot yet promise a
+stability guarantee or a fixed roadmap.
+
+## Ways to contribute
+
+- **File an issue.** Bug reports and design discussions are useful even if
+  you can't write the fix.
+- **Open a PR.** Small, focused PRs land faster than large ones. If you are
+  planning a substantial change (new service, schema change, new auth path),
+  please open an issue first so we can sanity-check the direction.
+- **Improve docs.** Anything in `docs/` is fair game. Doc-only PRs are
+  reviewed faster.
+- **Report security issues privately.** See [SECURITY.md](SECURITY.md) — do
+  not open a public issue for vulnerabilities.
+
+## Local development
+
+The fastest path to a running stack is the Docker + cloud-key path:
+
+```bash
+git clone https://github.com/jazzmind/busibox.git
+cd busibox
+cp env.local.example .env.local
+# Set OPENAI_API_KEY or ANTHROPIC_API_KEY in .env.local
+make docker-up
+```
+
+See [QUICKSTART.md](QUICKSTART.md) for details. Local-model inference (vLLM,
+Ollama, MLX) is optional — see
+[docs/administrators/local-models-addon.md](docs/administrators/local-models-addon.md).
+
+For Proxmox / Kubernetes / multi-host workflows, use the `busibox` CLI as
+described in [docs/administrators/01-quickstart.md](docs/administrators/01-quickstart.md).
+
+## Repository conventions
+
+Before adding files, please skim:
+
+- [CLAUDE.md](CLAUDE.md) — top-level project conventions
+- `.cursor/rules/001-documentation-organization.md` — where docs go
+- `.cursor/rules/002-script-organization.md` — where scripts go
+- `.cursor/rules/003-zero-trust-authentication.md` — auth rules (no shared
+  service-to-service secrets)
+- `.cursor/rules/010-make-commands.md` — `make` target reference
+
+Naming: `kebab-case` for filenames; descriptive prefixes for scripts
+(`deploy-*`, `setup-*`, `test-*`, `check-*`).
+
+## Pull request checklist
+
+Before requesting review:
+
+- [ ] The change has a clear, narrow scope. Unrelated cleanups belong in
+      separate PRs.
+- [ ] Tests are added or updated for behavioural changes, where practical.
+      For Python services: `make test-docker SERVICE=<name>`.
+      For the Rust CLI: `cd cli && cargo test`.
+- [ ] Documentation is updated for user-facing changes (new env vars,
+      flags, endpoints, or workflows).
+- [ ] Secrets are not committed. The default `.gitignore` covers most
+      cases; double-check vault files, `.env*`, and SSH keys.
+- [ ] No new service-to-service shared secrets — use the JWT/JWKS
+      Zero-Trust pattern (see rule 003).
+- [ ] If you touched dependencies, you've checked the license is permissive
+      (MIT/BSD/Apache-2.0/ISC). If it isn't, call it out in the PR
+      description so we can update [NOTICE](NOTICE).
+- [ ] CHANGELOG.md has an entry under `## [Unreleased]` for user-visible
+      changes.
+
+## Commit style
+
+We don't enforce conventional commits, but informative commit messages
+help. A useful pattern:
+
+    <area>: <imperative summary>
+
+    Why: one or two sentences on motivation.
+    What changed: bullets if needed.
+
+Examples already in `git log`:
+
+    feat: add app usage statistics endpoint and analytics support
+    fix: remove insecure default values and enhance vault sync logging
+
+## Code style
+
+- **Python**: target Python 3.11+. Each service has its own `requirements.txt`
+  and may use `ruff` / `pytest` configuration in `pyproject.toml`. Run any
+  formatters/linters that the service already configures before pushing.
+- **Rust**: `cd cli && cargo fmt && cargo clippy && cargo test`.
+- **TypeScript / JS**: follow the Next.js / app conventions; prefer the
+  shared `@jazzmind/busibox-app` library over reinventing utilities.
+
+## Code of conduct
+
+Participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). Please read it.
+
+## License
+
+By submitting a contribution, you agree that your contribution will be
+licensed under the project's [MIT License](LICENSE). You also confirm that
+you have the right to license the contribution under those terms (i.e. you
+wrote it, or it is otherwise compatibly licensed and properly attributed).
+
+We do not currently require a CLA. Inbound = outbound.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Wes Sonnenreich and Jazzmind contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,58 @@
+Busibox
+Copyright (c) 2026 Wes Sonnenreich and Jazzmind contributors
+
+This product is licensed under the MIT License (see LICENSE).
+
+The Busibox project source code is MIT-licensed. However, when building or
+running the platform, you may install third-party components and Docker images
+whose licenses differ from MIT. The list below is provided as a courtesy to
+help operators understand their distribution obligations. It is not legal
+advice — verify upstream licenses before redistributing a bundled image or
+product that includes these components.
+
+------------------------------------------------------------------------------
+Optional / feature-gated components with non-permissive licenses
+------------------------------------------------------------------------------
+
+The following Python dependencies are pulled in by the optional Marker /
+ColPali / advanced-PDF processing path of the data worker
+(srv/data/requirements.txt). They are not required for first-run evaluation
+and can be disabled via the MARKER_ENABLED=false and COLPALI_ENABLED=false
+environment flags.
+
+  - PyMuPDF (fitz)         — AGPL-3.0 (Artifex)
+  - pymupdf4llm            — AGPL-3.0
+  - pymupdf-layout         — AGPL-3.0
+  - marker-pdf             — source-available (verify pinned version's license)
+  - surya-ocr              — source-available (verify pinned version's license)
+  - poppler-utils (system) — GPL-2.0 (invoked as a subprocess by pdf2image)
+
+If you redistribute a Docker image or product that includes these components,
+you are responsible for complying with their respective licenses (which may
+include source-disclosure obligations).
+
+------------------------------------------------------------------------------
+Bundled third-party services (Docker images)
+------------------------------------------------------------------------------
+
+The default docker-compose.yml ships images for the following services. Their
+licenses apply to the images themselves, not to Busibox:
+
+  - PostgreSQL              — PostgreSQL License (permissive)
+  - Milvus                  — Apache-2.0
+  - etcd                    — Apache-2.0
+  - nginx                   — BSD-2-Clause
+  - LiteLLM                 — MIT (built locally)
+  - Redis 7                 — SSPL-1.0 / RSALv2 (source-available since 7.4)
+  - MinIO                   — AGPL-3.0
+  - Neo4j Community         — GPL-3.0
+  - vLLM                    — Apache-2.0 (optional, GPU profile)
+
+Operators who wish to ship a redistributable bundle under permissive terms
+should consider substituting Valkey for Redis and a permissively-licensed
+object store for MinIO. See docs/administrators/license-considerations.md
+(if present) and CHANGELOG.md for tracking notes.
+
+------------------------------------------------------------------------------
+Per-package license metadata for direct dependencies is tracked in the
+respective manifests (requirements.txt, Cargo.toml, package.json).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,271 +1,162 @@
-# Busibox Quickstart Guide
+# Busibox Quickstart
 
-**Complete local LLM infrastructure platform on Proxmox**
+> **The fastest path to a running Busibox is Docker + a cloud LLM API key.**
+> No GPU, no model downloads, no Proxmox needed for a first run.
 
-For comprehensive documentation, see [`specs/001-create-an-initial/quickstart.md`](specs/001-create-an-initial/quickstart.md)
-
----
-
-## Prerequisites
-
-**Proxmox Host**:
-- Proxmox VE installed and running
-- Ubuntu 22.04 LXC template downloaded
-- Network bridge configured (vmbr0)
-- SSH access to Proxmox host
-
-**Admin Workstation**:
-- Ansible 2.15+
-- SSH access to Proxmox host and containers
-- Python 3.8+ with pip
+This guide gets you to a working Portal at `http://localhost:3000` in
+~15 minutes. For multi-host (Proxmox / Kubernetes / fleet) deployments, see
+[docs/administrators/01-quickstart.md](docs/administrators/01-quickstart.md).
 
 ---
 
-## Quick Start (Production)
+## 1. Prerequisites
 
-### 1. Provision LXC Containers (Proxmox Host)
+- **Docker + Docker Compose** (Docker Desktop 4.20+ on macOS / Windows, or
+  Docker Engine 24+ on Linux)
+- **~16 GB free disk** for images and volumes
+- **One LLM provider key**, either:
+  - OpenAI: `OPENAI_API_KEY`
+  - Anthropic: `ANTHROPIC_API_KEY`
+  - AWS Bedrock: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION_NAME`
+- A **GitHub personal access token** with `read:packages` scope, used to
+  install the `@jazzmind/busibox-app` shared library
+  ([create one here](https://github.com/settings/tokens))
+
+You do **not** need an NVIDIA GPU, an Apple Silicon Mac, vLLM, MLX, or
+Ollama for a first run.
+
+---
+
+## 2. Clone and configure
 
 ```bash
-# On Proxmox host
-cd /root
 git clone https://github.com/jazzmind/busibox.git
-cd busibox/provision/pct
+cd busibox
 
-# Configure your environment
-vim vars.env  # Adjust CTIDs, IPs, template, storage if needed
-
-# Create containers
-bash create_lxc_base.sh
+cp env.local.example .env.local
 ```
 
-**Creates 7 containers**:
-- `200` - proxy-lxc (10.96.200.200)
-- `201` - apps-lxc (10.96.200.201)
-- `202` - agent-lxc (10.96.200.202)
-- `203` - pg-lxc (10.96.200.203)
-- `204` - milvus-lxc (10.96.200.204)
-- `205` - files-lxc (10.96.200.205)
-- `206` - ingest-lxc (10.96.200.206)
-- `207` - litellm-lxc (10.96.200.207)
-- `208` - vllm-lxc (10.96.200.208)
-
-### 2. Deploy Services (Admin Workstation)
+Open `.env.local` and set, at minimum:
 
 ```bash
-# On your workstation
-cd provision/ansible
+# One of these — whichever provider you have a key for
+OPENAI_API_KEY=sk-...
+# ANTHROPIC_API_KEY=sk-ant-...
+# AWS_ACCESS_KEY_ID=...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_REGION_NAME=us-east-1
 
-# Configure inventory (IPs should match vars.env)
-vim inventory/hosts.yml
+# Required to install the @jazzmind/busibox-app library at build time
+GITHUB_AUTH_TOKEN=ghp_...
 
-# Test connectivity
-make ping
-
-# Deploy all services
-make all
+# Optional — first user to sign up with this email becomes admin
+ADMIN_EMAIL=admin@localhost
 ```
 
-This deploys:
-- **PostgreSQL** with schema and RLS policies
-- **MinIO** with documents bucket
-- **Milvus** with vector collection
-- **Redis** + Ingest Worker
-- **Agent API** (FastAPI)
-- **Node.js** environment
-- **Deploywatch** for auto-updates
-
-### 3. Verify Deployment
-
-```bash
-cd provision/ansible
-make verify
-```
-
-Expected output:
-```
-✓ PostgreSQL is healthy
-✓ MinIO is healthy
-✓ Milvus is healthy
-✓ Agent API is healthy (or not deployed yet)
-✓ Database schema verified
-✓ Database migrations verified
-```
-
-### 4. Access Services
-
-| Service | URL | Credentials |
-|---------|-----|-------------|
-| **MinIO Console** | http://10.96.200.28:9001 | minioadmin /  |
-| **PostgreSQL** | 10.96.200.26:5432 | busibox_user / (see Ansible vars) |
-| **Milvus** | 10.96.200.27:19530 | (no auth) |
-| **Agent API** | http://10.96.200.30:8000/docs | (JWT required) |
-| **Redis** | 10.96.200.29:6379 | (no auth - internal) |
+The defaults for `POSTGRES_PASSWORD`, `MINIO_SECRET_KEY`,
+`AUTHZ_MASTER_KEY`, `BETTER_AUTH_SECRET`, etc. in `env.local.example` are
+**only suitable for local evaluation**. Rotate them before exposing the
+stack to anyone but yourself. The Busibox CLI does this automatically for
+non-local profiles.
 
 ---
 
-## Testing Mode
-
-Test infrastructure provisioning safely without affecting production:
+## 3. Start the stack
 
 ```bash
-# Create test environment (IDs 301-307, TEST- prefix)
-bash test-infrastructure.sh full
-
-# Or step-by-step:
-bash test-infrastructure.sh provision  # Create & configure
-bash test-infrastructure.sh verify     # Health checks
-bash test-infrastructure.sh cleanup    # Clean up
+make docker-up
 ```
 
-See [`docs/testing.md`](docs/testing.md) for details.
+This pulls and starts:
+
+- **Infrastructure**: PostgreSQL, Redis, MinIO, Milvus, Neo4j
+- **APIs**: AuthZ, Data, Search, Agent, Docs, Embedding, Deploy
+- **LLM gateway**: LiteLLM (configured with whichever provider key you set)
+- **Frontend**: nginx + the `core-apps` container running the Portal and
+  Agents apps
+
+First boot takes 5–15 minutes depending on your network and CPU.
+
+When `docker compose ps` shows everything `healthy`, open
+**<http://localhost:3000>** and sign up. The first account that matches
+`ADMIN_EMAIL` (or the first account at all if `ADMIN_EMAIL` is unset) is
+granted admin.
 
 ---
 
-## Post-Deployment Configuration
-
-### Change Default Passwords
-
-**MinIO** (files-lxc):
-```bash
-ssh root@10.96.200.28
-vim /srv/minio/.env
-# Change MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
-docker compose -f /srv/minio/docker-compose.yml restart
-```
-
-**PostgreSQL** (pg-lxc):
-```bash
-ssh root@10.96.200.26
-sudo -u postgres psql
-ALTER USER busibox_user WITH PASSWORD 'new_secure_password';
-```
-
-**JWT Secret** (agent-lxc):
-```bash
-ssh root@10.96.200.30
-vim /srv/agent/.env
-# Change JWT_SECRET_KEY to a secure random value
-systemctl restart agent-api
-```
-
-### Configure LLM Provider
-
-The platform uses liteLLM as a unified gateway. Configure your LLM provider:
-
-**Option 1: Ollama (Local)**
-```bash
-# Install Ollama on agent-lxc or separate container
-curl -fsSL https://ollama.com/install.sh | sh
-ollama serve
-
-# Update agent API config
-vim /srv/agent/.env
-# Set LITELLM_BASE_URL=http://localhost:11434
-```
-
-**Option 2: OpenAI**
-```bash
-# Update agent API config
-vim /srv/agent/.env
-# Set LITELLM_API_KEY=sk-...
-# Set LITELLM_BASE_URL=https://api.openai.com/v1
-```
-
-**Option 3: Custom Provider**
-```bash
-# Configure liteLLM on agent-lxc
-vim /etc/litellm/config.yaml
-# Add your provider configuration
-systemctl restart litellm
-```
-
-### Initialize First User
+## 4. Verify
 
 ```bash
-# Connect to PostgreSQL
-psql -h 10.96.200.26 -U busibox_user -d busibox
+# Watch service health
+docker compose ps
 
-# Create admin user
-INSERT INTO users (username, email, password_hash, is_active)
-VALUES ('admin', 'admin@example.com', 'hash_here', true);
+# Tail a service log
+docker compose logs -f authz-api
 
-# Assign admin role
-INSERT INTO user_roles (user_id, role_id)
-VALUES (
-  (SELECT id FROM users WHERE username = 'admin'),
-  (SELECT id FROM roles WHERE name = 'admin')
-);
+# Hit a health endpoint
+curl -s http://localhost:8001/health   # AuthZ
+curl -s http://localhost:8000/health   # Agent
 ```
+
+Try the platform end-to-end:
+
+1. Sign up at <http://localhost:3000>.
+2. Upload a PDF or text file via the Portal.
+3. Wait for ingestion (the Data API extracts, chunks, and embeds it).
+4. Ask the Agent a question that should be answered from the file.
+5. Confirm citations point back to your document.
+
+---
+
+## 5. Bring your own model (optional)
+
+The first-run path uses your cloud API key through LiteLLM, which means
+**Busibox itself is fully local but inference happens at your provider**.
+For air-gapped or fully on-prem deployments, install the local-model
+add-on pack — it adds Ollama / vLLM / MLX backends behind the same
+LiteLLM gateway, so your application code does not change.
+
+See [docs/administrators/local-models-addon.md](docs/administrators/local-models-addon.md)
+for the design and supported hardware.
+
+---
+
+## 6. Going further
+
+| You want to… | Go to |
+|---|---|
+| Configure SSO, custom domain, TLS | `docs/administrators/03-configure.md` |
+| Deploy to Proxmox LXC | `docs/administrators/02-install.md` and the `busibox` CLI |
+| Deploy to Kubernetes | `docs/administrators/11-kubernetes.md` |
+| Build a custom app on Busibox | `docs/administrators/04-apps.md` |
+| Add a new bridge channel (Telegram, Slack, …) | `docs/administrators/10-bridge-api-integrations.md` |
+| Run the security test suite | `make test-security` (see `tests/security/`) |
+| Contribute | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Report a vulnerability | [SECURITY.md](SECURITY.md) |
 
 ---
 
 ## Troubleshooting
 
-### Services Not Starting
+**A service is stuck in `starting`.** First boots are slow because the
+PostgreSQL schema, Milvus collections, and Neo4j constraints are all
+being created. Give it 5–15 minutes; then check `docker compose logs <svc>`.
 
-```bash
-# Check service status
-ssh root@<container-ip>
-systemctl status <service-name>
+**`@jazzmind/busibox-app` install fails.** You need a GitHub PAT with
+`read:packages` scope set as `GITHUB_AUTH_TOKEN`. The default
+`ghp_your_github_token` placeholder will fail with a 401.
 
-# View logs
-journalctl -u <service-name> -n 50 -f
-```
+**Agent returns "no LLM provider configured".** Confirm one of
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or the AWS Bedrock variables is set
+in `.env.local`, then `make docker-up` again to apply.
 
-### Health Checks Failing
+**"password authentication failed" against Postgres.** You changed
+`POSTGRES_PASSWORD` after the volume was created. Either revert the
+password or run `docker compose down -v` to wipe state and start fresh
+(this **deletes** uploaded documents and search indexes).
 
-```bash
-# Run health checks manually
-ssh root@10.96.200.26
-/usr/local/bin/minio-health-check && echo "MinIO OK"
-
-ssh root@10.96.200.27
-/usr/local/bin/milvus-health-check && echo "Milvus OK"
-
-ssh root@10.96.200.30
-/usr/local/bin/agent-api-health-check && echo "Agent OK"
-```
-
-### Database Connection Errors
-
-```bash
-# Test from agent container
-ssh root@10.96.200.30
-psql -h 10.96.200.26 -U busibox_user -d busibox -c "SELECT 1"
-```
-
-### Ansible Connection Errors
-
-```bash
-# Test SSH connectivity
-ssh root@10.96.200.26
-
-# Check Ansible inventory
-cd provision/ansible
-ansible -i inventory/hosts.yml all -m ping
-```
+For more, see `docs/administrators/08-troubleshooting.md`.
 
 ---
 
-## Next Steps
-
-1. **Upload Test File**: Use Agent API `/files/upload` endpoint
-2. **Verify Ingestion**: Check Redis streams and Milvus collection
-3. **Test Search**: Use Agent API `/search` endpoint
-4. **Configure OpenWebUI**: Point to Agent API LLM gateway
-5. **Deploy Custom Apps**: Add to deploywatch configuration
-
----
-
-## Additional Resources
-
-- **Architecture**: [`docs/architecture.md`](docs/architecture.md)
-- **Testing Guide**: [`docs/testing.md`](docs/testing.md)
-- **Full Quickstart**: [`specs/001-create-an-initial/quickstart.md`](specs/001-create-an-initial/quickstart.md)
-- **API Documentation**: http://10.96.200.30:8000/docs (after deployment)
-- **Constitution**: [`.specify/memory/constitution.md`](.specify/memory/constitution.md)
-
----
-
-**Version**: 1.0.0  
-**Last Updated**: 2025-10-14
+**Version**: 0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Busibox
 
+> **Project status — v0.1.0 (early preview).** Busibox is suitable for evaluation, lab use, and design-partner pilots. It has not yet had an independent security audit, and APIs/schemas may change before 1.0. See [CHANGELOG.md](CHANGELOG.md) for known limitations.
+
 **A self-hosted AI platform that keeps your data on your infrastructure.**
 
 Busibox integrates document processing, semantic search, AI agents, and custom applications into a single platform — running on Docker or Proxmox LXC containers with enterprise-grade security baked in.
@@ -106,9 +108,45 @@ Busibox is single-tenant and multi-user — each installation serves one organiz
 
 ---
 
-## Quick Start
+## Quick Start — Docker + a cloud API key (recommended for first run)
 
-The **Busibox CLI** is an interactive terminal UI that walks you through setup, deployment, and ongoing management. It handles SSH connectivity, encrypted vault passwords, model selection, and service health — all from one interface.
+The fastest way to evaluate Busibox is to run the whole stack locally on Docker and bring your own LLM API key. **No GPU and no local model downloads are required for a first run.** Local inference (vLLM / Ollama / MLX) is an optional add-on — see ["Optional: local inference"](#optional-local-inference) below.
+
+**Prerequisites:** Docker + Docker Compose, ~16 GB free disk for images, and one of: an OpenAI key, an Anthropic key, or AWS Bedrock credentials.
+
+```bash
+git clone https://github.com/jazzmind/busibox.git
+cd busibox
+
+# Start from the example env file and add a cloud LLM key
+cp env.local.example .env.local
+# Edit .env.local and set ONE of:
+#   OPENAI_API_KEY=sk-...
+#   ANTHROPIC_API_KEY=sk-ant-...
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION_NAME (for Bedrock)
+
+make docker-up
+```
+
+The Portal is then available at `http://localhost:3000`. The first user to sign up becomes the admin (configurable via `ADMIN_EMAIL`). See [QUICKSTART.md](QUICKSTART.md) for details, and [docs/administrators/](docs/administrators/) for the full operator guide.
+
+> **Why cloud-key by default?** A first-run evaluation should focus on the platform — auth, RAG, agents, search — not on model downloads, GPU drivers, or quantisation tradeoffs. Once you've verified Busibox does what you need, swap in local models with the add-on pack. See [docs/administrators/local-models-addon.md](docs/administrators/local-models-addon.md) for the design.
+
+### Optional: local inference
+
+For air-gapped or fully on-prem deployments, Busibox routes through LiteLLM to local backends:
+
+| Backend | Hardware | When to use |
+|---------|----------|-------------|
+| **Ollama** | CPU or any GPU | Easiest path; good for small/mid-sized models |
+| **vLLM** | NVIDIA GPU (recent) | Highest throughput on CUDA |
+| **MLX** | Apple Silicon | Fast on M-series Macs |
+
+The local-model add-on pack is documented at [docs/administrators/local-models-addon.md](docs/administrators/local-models-addon.md). For multi-host or Proxmox deployments, the Busibox CLI handles GPU detection and model selection automatically.
+
+### For multi-host / Proxmox / Kubernetes
+
+The **Busibox CLI** is an interactive terminal UI that walks you through profile setup, hardware profiling, model selection, and deployment across Docker, Proxmox LXC, and Kubernetes targets. It handles SSH connectivity, encrypted vault passwords, and service health from one interface.
 
 ```bash
 cd cli/busibox
@@ -116,17 +154,7 @@ cargo build --release
 ./target/release/busibox
 ```
 
-The CLI guides you through:
-
-1. **Profile setup** — configure Docker, Proxmox, or Kubernetes targets
-2. **Hardware profiling** — detect GPUs and available resources
-3. **Model selection** — choose and download AI models for your hardware
-4. **Deployment** — install all services with proper secrets injection
-5. **Management** — restart, monitor, redeploy, and view logs
-
-Manage multiple Busibox installations (Docker, Proxmox, Kubernetes — self-hosted or cloud) from a single workstation through deployment profiles.
-
-See [docs/administrators/](docs/administrators/) for full deployment and configuration guides.
+See [docs/administrators/01-quickstart.md](docs/administrators/01-quickstart.md) for the full CLI flow.
 
 ---
 
@@ -225,9 +253,19 @@ busibox/                        # This repo — infrastructure, APIs, provisioni
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide. The short version:
+
 1. Read the architecture docs in [docs/developers/architecture/](docs/developers/architecture/)
 2. Set up a local development environment with Docker: `make install SERVICE=all`
 3. Run tests: `make test-docker SERVICE=<service>`
 4. Follow the organization rules in `.cursor/rules/` for file placement and naming
 
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). Security issues should be reported privately — see [SECURITY.md](SECURITY.md).
+
 See [CLAUDE.md](CLAUDE.md) for detailed development workflow and conventions.
+
+---
+
+## License
+
+Busibox is released under the [MIT License](LICENSE). The project source code is MIT-licensed; some optional and bundled third-party components carry their own licenses. See [NOTICE](NOTICE) for the per-component breakdown — most relevant for operators who plan to redistribute a Docker image of the platform.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Project status
+
+Busibox is early-stage software (v0.1.x). It is intended for evaluation,
+self-hosted lab use, and design-partner pilots. **It has not yet been
+audited by an independent security firm.** See [CHANGELOG.md](CHANGELOG.md)
+for known limitations.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅ — current development line, fixes go here |
+| < 0.1.0 | ❌ — pre-release, not supported |
+
+We will publish a clearer support window once the project reaches 1.0.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security reports.**
+
+Email the maintainers at:
+
+    security@jazzmind.com
+
+(or, if that bounces, `wes@sonnenreich.com`).
+
+Please include:
+
+- A description of the issue and the affected component (e.g. AuthZ API,
+  Data API, CLI, Docker image, etc.)
+- Steps to reproduce, ideally with a minimal proof-of-concept
+- The version / commit SHA you tested against
+- Any logs, request traces, or scanner output that helps us reproduce
+- Your name / handle if you'd like credit in the release notes
+
+We will acknowledge receipt within **3 business days** and aim to provide an
+initial assessment (severity, fix plan, expected timeline) within **10 business
+days**. For high-severity issues, we will coordinate a disclosure timeline
+with you before publishing details.
+
+## Scope
+
+In scope:
+
+- The Busibox source code in this repository (`srv/`, `cli/`, `tools/`,
+  `scripts/`, `provision/`, default `docker-compose.yml`)
+- Default configurations shipped in `env.local.example` and the Ansible roles
+
+Out of scope:
+
+- Vulnerabilities in upstream third-party dependencies that we vendor
+  unmodified — please report those upstream and copy us
+- Findings that require operator misconfiguration explicitly warned against
+  in the documentation (e.g. running with default `devpassword` values in
+  production, exposing internal-only services to the public internet)
+- Denial-of-service from unbounded user-supplied AI workloads — the platform
+  ships rate limits and cost ceilings, but tuning them is the operator's
+  responsibility
+
+## Hardening guidance
+
+Operators preparing a production deployment should review:
+
+- `docs/administrators/03-configure.md` — secret rotation, vault setup
+- `docs/developers/architecture/` — Zero-Trust auth model, RLS, JWT scopes
+- `tests/security/` — OWASP API Security Top 10 test suite (run with
+  `make test-security`)
+
+## Credit
+
+We maintain a list of researchers who have responsibly disclosed issues in
+the release notes for each version. Let us know if you'd prefer to remain
+anonymous.

--- a/docs/administrators/01-quickstart.md
+++ b/docs/administrators/01-quickstart.md
@@ -8,7 +8,16 @@ published: true
 
 # Administrator Quick Start
 
-This guide gets you from zero to a running Busibox instance as fast as possible. For detailed explanations, see the individual guides linked throughout.
+This guide covers the **multi-host / Proxmox / Kubernetes** flow via the
+Busibox CLI. For a single-machine first-run evaluation, start with the
+Docker-only path in [QUICKSTART.md](../../QUICKSTART.md) — it does not
+require a GPU, Rust toolchain, or remote host.
+
+> **First-run recommendation:** evaluate Busibox on local Docker with a
+> cloud LLM API key (OpenAI, Anthropic, or AWS Bedrock). Once you've
+> confirmed the platform fits, use this guide to bring up a real
+> deployment, and add local inference via the
+> [local-models add-on pack](./local-models-addon.md) when you're ready.
 
 ## Prerequisites
 

--- a/docs/administrators/local-models-addon.md
+++ b/docs/administrators/local-models-addon.md
@@ -1,0 +1,201 @@
+---
+title: "Local Models Add-on Pack (design)"
+category: "administrator"
+order: 12
+description: "Design for an optional add-on pack that adds local inference (Ollama / vLLM / MLX) to a Busibox install. Status: proposed."
+published: true
+---
+
+# Local Models Add-on Pack — Design
+
+> **Status:** proposed for v0.2.x. Not yet implemented as a single command.
+> The underlying backends (vLLM, Ollama, MLX) already exist in the
+> repository today; this document describes how we intend to package them
+> as a coherent, opt-in "add-on pack" so that the **default** Busibox
+> install does not require a GPU.
+
+---
+
+## Why an add-on pack?
+
+The default Busibox first-run path (see [QUICKSTART.md](../../QUICKSTART.md))
+uses LiteLLM with a cloud provider key (OpenAI / Anthropic / AWS Bedrock).
+This is deliberate:
+
+- **Faster evaluation.** No GPU drivers, model downloads, or
+  quantisation tradeoffs to worry about before you've decided whether
+  Busibox does what you need.
+- **Predictable hardware story.** The Docker stack runs on any laptop;
+  local inference adds real hardware constraints (CUDA driver versions,
+  Apple Silicon minimums, RAM headroom for KV cache).
+- **Cleaner OSS bundle.** Local-inference toolchains pull in larger
+  images and, in some cases, model weights with non-permissive licenses.
+  Keeping them out of the default install means the default install is
+  easier to redistribute.
+
+Users who need air-gapped operation or want to avoid per-token cloud
+costs add the local-models pack on top of a working Busibox install.
+
+---
+
+## Goals
+
+1. **One-command install.** `busibox addon install local-models` (or
+   `make addon-local-models`) brings up the appropriate backend for the
+   detected hardware and registers it with LiteLLM.
+2. **No application changes.** Apps continue to call LiteLLM by name;
+   the pack is invisible to consumers of the Agent API.
+3. **Hardware-aware defaults.** The pack auto-selects vLLM on NVIDIA,
+   MLX on Apple Silicon, and Ollama as the universal fallback.
+4. **Reversible.** `busibox addon remove local-models` cleanly tears
+   down containers, leaves model files behind by default, and offers
+   `--purge` to delete them.
+5. **Coexists with cloud.** Users can mix-and-match — e.g. local model
+   for embeddings and routine extraction, cloud model for the agent's
+   reasoning step.
+
+---
+
+## Proposed profiles
+
+LiteLLM is the single point of routing. The pack contributes one or more
+*profiles* to `litellm-config.yaml`. Each profile is a named model that
+agents can target.
+
+| Profile name           | Backend     | Hardware                    | Default model                     | Use case |
+|------------------------|-------------|-----------------------------|------------------------------------|----------|
+| `local-fast`           | Ollama      | CPU or any GPU              | `qwen2.5:7b-instruct`             | Quick extraction, classification |
+| `local-quality`        | vLLM        | NVIDIA (24 GB+)             | `Qwen/Qwen2.5-32B-Instruct-AWQ`   | Reasoning, RAG synthesis |
+| `local-mlx`            | MLX         | Apple Silicon (32 GB+)      | `mlx-community/Qwen2.5-32B-Instruct-4bit` | Mac Studio / M-series |
+| `local-embed`          | FastEmbed   | CPU                          | `BAAI/bge-large-en-v1.5`          | Already shipped — listed for reference |
+| `local-vision`         | vLLM        | NVIDIA (40 GB+)             | `Qwen/Qwen2.5-VL-7B-Instruct`     | Optional: ColPali / vision |
+| `cloud-openai`         | LiteLLM     | n/a                          | `gpt-4o-mini`                     | Already shipped — for reference |
+| `cloud-anthropic`      | LiteLLM     | n/a                          | `claude-3-5-haiku-latest`         | Already shipped — for reference |
+| `cloud-bedrock`        | LiteLLM     | n/a                          | `bedrock/us.anthropic.claude-3-5-haiku-v1:0` | Already shipped — for reference |
+
+The `cloud-*` rows above already work today; they're listed to make the
+routing story explicit. The add-on pack contributes the `local-*` rows.
+
+### Routing recommendations
+
+Agents declare the profile they want, not the underlying model. Sensible
+defaults out of the pack:
+
+- **Agent reasoning** → `local-quality` if available, fall back to
+  `cloud-anthropic`
+- **Schema extraction** → `local-fast`
+- **Embeddings** → `local-embed` (already default)
+- **Vision** → `local-vision` if `COLPALI_ENABLED=true`, otherwise
+  cloud
+
+Per-agent overrides remain available through the existing agent config.
+
+---
+
+## Install UX
+
+```bash
+# From a working Busibox install
+busibox addon list                       # discover available add-ons
+busibox addon install local-models       # detects hardware, prompts to confirm
+busibox addon install local-models \
+    --backend vllm \
+    --model Qwen/Qwen2.5-32B-Instruct-AWQ
+busibox addon status local-models        # shows what's registered
+busibox addon remove local-models        # tear down (keeps model files)
+busibox addon remove local-models --purge
+```
+
+What `install` does:
+
+1. **Hardware detection.** Reuse `busibox-providers::GpuProvider` to
+   identify NVIDIA / Apple Silicon / CPU-only.
+2. **Backend selection.** Pick vLLM, MLX, or Ollama based on hardware
+   and any `--backend` override.
+3. **Model selection.** Offer a small curated list per backend; a
+   `--model` flag lets advanced users override.
+4. **Disk-space check.** Refuse to start if free space is below the
+   selected model size + 20% headroom.
+5. **Container / service start.** For Docker installs: bring up an
+   additional compose profile (`docker compose --profile local-models
+   up -d`). For Proxmox: deploy a new role into the existing LLM
+   container. For K8s: apply a Helm chart.
+6. **LiteLLM registration.** Append the profile(s) to
+   `litellm-config.yaml`, reload LiteLLM.
+7. **Smoke test.** Send a 1-token completion through the new profile;
+   refuse to mark the install successful otherwise.
+
+For the Docker case, the add-on is implementable today as
+`docker-compose.local-models.yml` overlay activated via a make target.
+
+---
+
+## Hardware caveats
+
+- **NVIDIA / vLLM.** Requires CUDA 12.x driver compatible with the
+  selected vLLM build. Multi-GPU works but tensor-parallel sizing
+  requires manual tuning. KV-cache requirements grow with sequence
+  length — long-context models can OOM on 24 GB cards.
+- **Apple Silicon / MLX.** Requires an M-series Mac with at least
+  32 GB unified memory for 32B-class models at 4-bit. Throughput is
+  good for single-user; not a substitute for a GPU in a multi-user
+  deployment.
+- **CPU / Ollama.** Works everywhere but slow on anything bigger than
+  ~7B. Best for embedding work, classification, and dev environments.
+- **Disk.** Plan for 5–80 GB per model depending on size and
+  quantisation. Default model files live under
+  `/var/lib/busibox/models` (configurable).
+- **Networking.** First model pull is bandwidth-heavy. The pack
+  supports a pre-staged model cache so air-gapped installs can copy
+  model files in manually.
+
+---
+
+## Acceptance criteria
+
+The pack is "done" for a 0.2.x release when:
+
+1. `busibox addon install local-models` succeeds end-to-end on **all
+   four** of: Linux + NVIDIA, macOS + Apple Silicon, Linux + CPU-only,
+   and a fresh Proxmox LXC profile.
+2. After install, an agent configured to use `local-quality` (or the
+   chosen backend's profile) returns an answer to a known RAG query
+   that matches a baseline answer from `cloud-anthropic` within an
+   evaluator tolerance.
+3. `busibox addon status local-models` reports correct backend, model,
+   GPU utilisation, and last-call latency.
+4. `busibox addon remove local-models` leaves the rest of the platform
+   functional and removes the LiteLLM profile entries.
+5. The default Docker install (no add-on, cloud key only) **continues
+   to work** without any local-inference dependencies on disk or in
+   the running image set.
+6. NOTICE/CHANGELOG updated with any new licenses pulled in by the
+   pack (e.g. model weights with non-commercial clauses must be opt-in
+   only and clearly flagged).
+
+---
+
+## Open questions
+
+- **Model weight licensing.** Several strong open-weight models
+  (Llama, Gemma, some Qwen variants) ship under custom licenses with
+  acceptable-use clauses. We will not pre-select any weight whose
+  license is non-permissive without an explicit `--accept-license`
+  flag and a one-line summary at install time.
+- **Model registry.** Curate inside the repo, or fetch a JSON catalog
+  at runtime so we can add models without a new release? Lean toward
+  the former for v0.2.x to keep the supply chain simple.
+- **Multi-tenant routing.** Today, a single LiteLLM is shared across
+  agents. Per-tenant rate limits and budgets exist. Per-tenant
+  *backends* (e.g. one tenant's traffic goes to local, another's to
+  Bedrock) is out of scope for v0.2.x.
+
+---
+
+## Tracking
+
+- This design lives in [docs/administrators/local-models-addon.md](./local-models-addon.md).
+- Implementation work will be tracked under the v0.2 milestone.
+- Until the pack ships, the existing per-service knobs
+  (`VLLM_BASE_URL`, `MARKER_USE_GPU`, etc. in `env.local.example`)
+  remain the supported way to enable local inference manually.

--- a/docs/developers/release-checklist.md
+++ b/docs/developers/release-checklist.md
@@ -1,0 +1,102 @@
+---
+title: "Release Checklist"
+category: "developer"
+order: 99
+description: "Step-by-step checklist for cutting a Busibox release."
+published: true
+---
+
+# Release Checklist
+
+This is the canonical procedure for tagging a Busibox release. v0.1.0 is
+the first public release.
+
+> **Important:** Releases are **only** cut by a maintainer with push
+> rights to `main` and the upstream remote. AI agents must not push tags
+> or publish GitHub releases unsupervised.
+
+---
+
+## Pre-flight
+
+- [ ] All target PRs merged to `main`. No open PRs labelled `release-blocker`.
+- [ ] CHANGELOG.md has a section for the new version with date, populated
+      from the `## [Unreleased]` queue.
+- [ ] The version string is consistent across:
+    - `CHANGELOG.md` (top entry)
+    - `cli/*/Cargo.toml` (`version = "0.1.0"` in each crate that ships a binary)
+    - `tools/mcp-*/package.json` (`"version": "0.1.0"`)
+    - `QUICKSTART.md` ("Version" footer)
+- [ ] `LICENSE` and `NOTICE` are in repo root and up to date. If any new
+      non-permissively-licensed dependency landed since the last release,
+      it is captured in `NOTICE`.
+- [ ] `SECURITY.md` contact details are correct.
+- [ ] CI is green on `main`.
+
+## Sanity checks
+
+Run these locally before tagging:
+
+```bash
+# Rust workspace builds and tests
+cd cli && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
+cd ..
+
+# Quickstart works end-to-end with a cloud key
+cp env.local.example .env.local
+# (edit: set OPENAI_API_KEY, GITHUB_AUTH_TOKEN)
+make docker-up
+# Confirm: localhost:3000 loads, signup works, file upload works,
+#          agent answers a RAG question with citations.
+
+# Security test suite, if applicable to the change set
+make test-security
+```
+
+## Tag and release
+
+> Do not run these unless you are the maintainer with intent to publish.
+
+```bash
+# 1. Make sure main is clean
+git checkout main && git pull --ff-only
+
+# 2. Confirm the changelog entry is present
+grep -n "^## \[0.1.0\]" CHANGELOG.md
+
+# 3. Create an annotated, signed tag
+git tag -s v0.1.0 -m "Busibox v0.1.0"
+
+# 4. Push the tag
+git push origin v0.1.0
+
+# 5. Draft the GitHub release from the tag, using the v0.1.0 section of
+#    CHANGELOG.md as the body. Mark as "latest release".
+gh release create v0.1.0 \
+    --title "Busibox v0.1.0" \
+    --notes-file <(awk '/^## \[0.1.0\]/{flag=1} /^## \[/{if (flag && !/^## \[0.1.0\]/) exit} flag' CHANGELOG.md) \
+    --verify-tag
+```
+
+If you'd rather draft in the UI, paste the v0.1.0 section of CHANGELOG.md
+into the release body and tick "Set as the latest release".
+
+## Post-release
+
+- [ ] Announce the release on the channels we use (README badges,
+      Discussions, Twitter / Mastodon if applicable).
+- [ ] Open a "Post-release" issue listing follow-ups discovered during
+      the release process so they don't get lost.
+- [ ] Reset CHANGELOG.md to have an empty `## [Unreleased]` section
+      under the new version.
+
+## Rollback
+
+If a critical issue is found post-release:
+
+1. **Don't delete the tag** — that breaks consumers who already pulled.
+2. Cut a `0.1.1` patch release with the fix, following this same
+   checklist. Reference the original release in the CHANGELOG.
+3. If the original release is dangerous to use (security or data-loss),
+   mark it as a pre-release in the GitHub UI and update the release
+   notes with a banner pointing to the patch.

--- a/docs/developers/release-notes-v0.1.0.md
+++ b/docs/developers/release-notes-v0.1.0.md
@@ -1,0 +1,70 @@
+---
+title: "Release notes — v0.1.0 (draft)"
+category: "developer"
+order: 100
+description: "Draft release notes for the first public Busibox release. Source for the GitHub release body."
+published: false
+---
+
+# Busibox v0.1.0 (draft)
+
+**The first public, MIT-licensed release of Busibox.** This is an
+early-stage preview suitable for evaluation, lab use, and design-partner
+pilots — not a production-ready 1.0.
+
+If you're new to Busibox, start with the
+**[Quickstart](https://github.com/jazzmind/busibox/blob/main/QUICKSTART.md)**:
+clone the repo, drop an OpenAI / Anthropic / Bedrock key into
+`.env.local`, run `make docker-up`, and you've got a working stack on
+your laptop in ~15 minutes. No GPU, no model downloads, no Proxmox
+required for a first run.
+
+## Highlights
+
+- 🏠 **Self-hosted document + agent platform.** Upload files, hybrid
+  search across them, and run AI agents that cite their sources — all
+  on your own hardware.
+- 🔐 **Zero-Trust auth from day one.** RS256 JWTs verified via JWKS,
+  per-service audience-scoped subject token exchange, no shared
+  service-to-service secrets.
+- 🛡️ **PostgreSQL Row-Level Security** end-to-end. Even an application
+  bug can't return rows the user shouldn't see.
+- 🤖 **Hybrid LLM routing** through LiteLLM: cloud (OpenAI / Anthropic /
+  Bedrock) by default, with vLLM / MLX / Ollama available as opt-in
+  local backends.
+- 🧰 **Three MCP servers** for AI coding agents (Cursor / Claude Code):
+  `mcp-core-dev`, `mcp-app-builder`, `mcp-admin`.
+- 🦀 **Busibox CLI** — a Rust workspace that drives multi-host
+  deployment across Docker, Proxmox LXC, and Kubernetes.
+
+See the full list in
+[CHANGELOG.md](https://github.com/jazzmind/busibox/blob/main/CHANGELOG.md).
+
+## Known limitations
+
+- No independent security audit yet.
+- The optional Marker / advanced-PDF processing path pulls AGPL /
+  source-available components (PyMuPDF, marker-pdf, surya-ocr); the
+  Busibox source is MIT but operators redistributing a Docker image
+  with these enabled must comply with their licenses. Disable with
+  `MARKER_ENABLED=false` and `COLPALI_ENABLED=false`. See
+  [NOTICE](https://github.com/jazzmind/busibox/blob/main/NOTICE).
+- Bundled service images (Redis 7, MinIO, Neo4j Community) carry their
+  own non-MIT licenses; this affects redistribution of a bundled
+  image, not the Busibox source.
+- Single-tenant by design — multi-org tenancy is not on the 0.1
+  roadmap.
+- Schema and API churn expected before 1.0.
+
+## Reporting issues
+
+- Bugs / features → GitHub Issues with the supplied templates.
+- Security → see
+  [SECURITY.md](https://github.com/jazzmind/busibox/blob/main/SECURITY.md);
+  please report privately, not in a public issue.
+
+## Thanks
+
+To the early users running Busibox on Proxmox clusters, Mac Studios,
+and Kubernetes spot fleets — your bug reports and "this would be
+nicer if…" feedback shaped this release.


### PR DESCRIPTION
## Summary

This PR adds the launch-critical OSS files and reshapes first-run docs so a new user can evaluate Busibox in ~15 minutes with **Docker + a cloud LLM API key** — no GPU, no model downloads, no Proxmox required.

- Adds MIT `LICENSE` and a `NOTICE` that enumerates per-component license obligations for bundled and optional third-party components
- Adds OSS governance: `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml`, `.github/PULL_REQUEST_TEMPLATE.md`
- Adds `CHANGELOG.md` with a populated `[0.1.0]` section, including known limitations and the licensing footnotes
- Reshapes `README.md` and rewrites `QUICKSTART.md` so the recommended first run is `cp env.local.example .env.local` → set an OpenAI / Anthropic / Bedrock key → `make docker-up`
- Demotes the Proxmox CLI flow to `docs/administrators/01-quickstart.md` with a banner pointing new users at the Docker path
- Adds a design doc for an opt-in **local-models add-on pack** (Ollama / vLLM / MLX) at `docs/administrators/local-models-addon.md`
- Adds a maintainer-run release checklist (`docs/developers/release-checklist.md`) and draft release notes (`docs/developers/release-notes-v0.1.0.md`)

## Licensing — what we found

The project source can ship under MIT. **The friction is in `srv/data/requirements.txt`**, which pulls AGPL components for the optional Marker / advanced-PDF path:

- `PyMuPDF`, `pymupdf4llm`, `pymupdf-layout` — AGPL-3.0
- `marker-pdf`, `surya-ocr` — historically GPL-3.0, recent versions use custom source-available licenses (pinned versions should be verified before redistributing a bundled image)

These are gated behind existing `MARKER_ENABLED` / `COLPALI_ENABLED` env flags and are **not required for first-run evaluation**. They are documented in `NOTICE`.

Bundled service images (Redis 7 SSPL/RSALv2, MinIO AGPL, Neo4j Community GPL-3) also carry non-MIT licenses; this affects redistribution of a bundled image, not the Busibox source license. Tracked in `NOTICE` for follow-up (Valkey is the obvious Redis swap when we want a clean redistributable bundle).

Rust CLI deps and JS MCP-server deps are all permissive — no blockers.

## Release publishing — NOT done in this PR

Per the maintainer's request, this PR does **not** publish a GitHub release or push tags. The exact maintainer-run commands are documented in `docs/developers/release-checklist.md`. Briefly, after merging:

```bash
git checkout main && git pull --ff-only
git tag -s v0.1.0 -m "Busibox v0.1.0"
git push origin v0.1.0
gh release create v0.1.0 --title "Busibox v0.1.0" --notes-file <(...) --verify-tag
```

## Test plan

- [x] YAML in `.github/ISSUE_TEMPLATE/*.yml` parses cleanly (validated with `python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Markdown links in modified docs resolve to existing files
- [ ] Manual: walk through the new QUICKSTART on a clean machine with an OpenAI key
- [ ] Manual: confirm `make docker-up` still works after the doc-only changes
- [ ] Manual: run `cd cli && cargo fmt --check && cargo clippy && cargo test`
- [ ] Manual: run `make test-security`

(The agent that prepared this PR did not have Docker or the Rust toolchain available in its sandbox — those manual checks are for a maintainer to run before merge.)

## Caveats — please don't overclaim

This is a **v0.1.0 preview**, not a 1.0. The CHANGELOG and SECURITY.md both say so explicitly. No independent security audit yet, schema/API churn expected, single-tenant by design. Please don't market it otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)